### PR TITLE
Fix infinite fetch loop in TasksDone

### DIFF
--- a/Mental-Health/src/components/TasksDone.js
+++ b/Mental-Health/src/components/TasksDone.js
@@ -74,7 +74,7 @@ const TaskDone = () => {
 
   useEffect(() => {
     fetchTasks();
-  });
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- prevent repeated refetching of tasks by adding dependency array to the effect hook

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd89b4eb0832b9e76232baac0f665